### PR TITLE
Replace hackerschool.com with recurse.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@
 function Client() {
   this.token = null;
   this.apiUrls = {
-    base: 'https://www.hackerschool.com/api/v1/',
-    batches: 'https://www.hackerschool.com/api/v1/batches/',
-    people: 'https://www.hackerschool.com/api/v1/people/'
+    base: 'https://www.recurse.com/api/v1/',
+    batches: 'https://www.recurse.com/api/v1/batches/',
+    people: 'https://www.recurse.com/api/v1/people/'
   };
 
   this.people = require('./lib/people')(this);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,7 +3,7 @@
 var Q = require('q'),
     simpleOAuth = require('simple-oauth2');
 
-var HS_API_URL = 'https://www.hackerschool.com';
+var HS_API_URL = 'https://www.recurse.com';
 
 /**
  * @class Auth class constructor


### PR DESCRIPTION
We thought we could switch to recurse.com without breaking existing OAuth clients, but that turned out not to be the case. =( Really sorry!

This updates various instances of hackerschool.com to be recurse.com.
